### PR TITLE
Two (rather crucial!) typos in the instructions to clone the repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ From Python package index:
 
 or from Github source:  
 
-    git clone https://github.com/peterhil/leftb.git
+    git clone https://github.com/peterhil/leftrb.git
     cd leftrb 
-    python setyp.py install
+    python setup.py install
 
 ## About
 


### PR DESCRIPTION
The errors should be corrected also on the PyPI page (https://pypi.python.org/pypi/leftrb)
