### PR TITLE
Update packaging dependency and supported python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ MANIFEST
 leftrb.egg-info/
 .coverage
 .tox/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/leftrb/test/test_llrb.py
+++ b/leftrb/test/test_llrb.py
@@ -16,7 +16,7 @@ Tree = LeftRB
 
 def fill_tree(items):
     tree = Tree()
-    map(tree.insert, items)
+    list(map(tree.insert, items))
     return tree
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     version=PACKAGE_VERSION,
     packages=PACKAGES,
     requires=[],
-    install_requires=['distribute'],
+    install_requires=[],
     tests_require=['pytest>=2.3.4'],
     scripts=[],
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,pypy
+envlist = py27,py34,py35,py36,pypy,pypy3
 
 [testenv]
 changedir = leftrb/test
@@ -9,5 +9,4 @@ deps =
 
 commands =
     py.test {posargs} \
-        --basetemp={envtmpdir}  \ # py.test tempdir setting
-        []                        # substitute with tox' positional arguments
+        --basetemp={envtmpdir}  # py.test tempdir setting


### PR DESCRIPTION
In my environment (macOS 10.11.6), this change works well.

```bash
(leftrb) $ tox
  ...
  py27: commands succeeded
  py34: commands succeeded
  py35: commands succeeded
  py36: commands succeeded
  pypy: commands succeeded
  pypy3: commands succeeded
  congratulations :)
```